### PR TITLE
fixes for the `foscat` demo

### DIFF
--- a/foscat-xarray-interface-demo.ipynb
+++ b/foscat-xarray-interface-demo.ipynb
@@ -99,8 +99,9 @@
    "source": [
     "%%time\n",
     "stats = foscat.reference_statistics(\n",
-    "    arr - arr.median(dim=\"cells\"), parameters=params, variances=True\n",
+    "    arr - arr.median(), parameters=params, variances=True\n",
     ")\n",
+    "stats.attrs[\"foscat_backend\"] = params.cache.backend\n",
     "stats"
    ]
   },
@@ -157,6 +158,7 @@
     "    parameters=params,\n",
     "    variances=True,\n",
     ")\n",
+    "stats.attrs[\"foscat_backend\"] = params.cache.backend\n",
     "stats"
    ]
   },

--- a/foscat-xarray-interface-demo.ipynb
+++ b/foscat-xarray-interface-demo.ipynb
@@ -86,7 +86,7 @@
    "outputs": [],
    "source": [
     "params = foscat.Parameters(\n",
-    "    n_orientations=4, kernel_size=5, jmax_delta=0, dtype=\"float64\", backend=\"torch\"\n",
+    "    n_orientations=4, kernel_size=5, jmax_delta=0, dtype=\"float32\", backend=\"torch\"\n",
     ")"
    ]
   },


### PR DESCRIPTION
It appears we can't just reconstruct the backend from just the string anymore, so until this has been fixed in the `xarray` API we need to copy the existing backend into the attrs.